### PR TITLE
Updated kronos-step to version 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "kronos-step": "1.2.1"
+    "kronos-step": "1.2.2"
   }
 }


### PR DESCRIPTION
:rocket:

kronos-step just published version 1.2.2, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 1 commits (ahead by 1, behind by 0).

- [2390154](https://github.com/Kronos-Integration/kronos-step/commit/239015408f4815f138ffd7a8809e7ec3639f98e8): fix: step-status keys

See the [full diff](https://github.com/Kronos-Integration/kronos-step/compare/13a533949d540c9549787b4ad553e4ca6aa48042...239015408f4815f138ffd7a8809e7ec3639f98e8).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>